### PR TITLE
Update AWS:IAM:Role properties.json

### DIFF
--- a/config/properties/resource-types/AWS::IAM::Role.properties.json
+++ b/config/properties/resource-types/AWS::IAM::Role.properties.json
@@ -30,6 +30,7 @@
   "relationships.resourceName": "string",
   "relationships.resourceType": "string",
   "resourceCreationTime": "string",
+  "resourceLastActivity": "string",
   "resourceId": "string",
   "resourceName": "string",
   "resourceType": "string",


### PR DESCRIPTION
Add "resourceLastActivity" property for using it in querys that need this data as a key value.

*Issue: IAM Role resource property. #20*

*Add "resourceLastActivity" property for using it in querys that need this data as a key value*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
